### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./spark.js"
+  "name": "@quilt/spark",
+  "version": "0.0.1",
+  "main": "./spark.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }

--- a/spark.js
+++ b/spark.js
@@ -1,3 +1,4 @@
+const {Container, Service, publicInternet, LabelRule} = require("@quilt/quilt");
 var image = "quilt/spark";
 
 function setImage(newImage) {

--- a/sparkPI.js
+++ b/sparkPI.js
@@ -1,5 +1,5 @@
-// Import spark.js
-var spark = require("github.com/quilt/spark");
+const {createDeployment, Machine, publicInternet, githubKeys, enough} = require("@quilt/quilt");
+var spark = require("./spark.js");
 
 var deployment = createDeployment({});
 


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.